### PR TITLE
fix: correctly scale amount when purchasing per quantity unit

### DIFF
--- a/grocy/src/structs.rs
+++ b/grocy/src/structs.rs
@@ -18,7 +18,9 @@ impl Display for ShoppingLocation {
 pub struct ProductDetails {
     pub product: Product,
     pub product_barcodes: Vec<ProductBarcode>,
+    pub quantity_unit_stock: QuantityUnit,
     pub default_quantity_unit_purchase: QuantityUnit,
+    pub qu_conversion_factor_purchase_to_stock: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,4 +8,8 @@ pub enum Error {
     SkippedProduct,
     #[error("Expected barcode associated with its product to have an amount, but it didn't")]
     BarcodeAmountNotFound,
+    #[error("Expected barcode associated with its product to have a quantity unit, but it didn't")]
+    BarcodeQuantityUnitNotFound,
+    #[error("Barcode's quantity unit (#{0}) is not its product's stock nor purchase default")]
+    BarcodeQuantityUnitUnsupported(u32),
 }


### PR DESCRIPTION
Grocy unfortunately does not allow setting a quantity unit when purchasing, so intead the quantity (and price) need to be scaled to the stock quantity unit.

It also seems like it is only possible to do that when the purchasing quantity unit is either the stock QU itself (and so no scaling is necessaryy) or when it is the default purchasing QU (in which case Grocy's product details include the conversion factor). In order to support other arbitrary QUs, we would need to make an additional request [`GET /objects/quantity_unit_conversions_resolved`], but this commit avoids that by simply reporting an error to the user.