### PR TITLE
refactor: use intermediate representation for receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "ir"
+version = "1.2.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +636,7 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "ir",
  "oauth2",
  "reqwest",
  "serde",
@@ -644,6 +653,7 @@ dependencies = [
  "confy",
  "grocy",
  "inquire",
+ "ir",
  "lidl",
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 [workspace.dependencies]
 anyhow = "1.0.79"
 chrono = { version = "0.4.31", default-features = false, features = ["alloc", "clock", "std"] }
+ir = { path = "ir" }
 reqwest = { version = "0.11.23", features = ["blocking", "json"] }
 serde = { version = "1.0.195", features = ["derive"] }
 thiserror = "1.0.56"
@@ -26,6 +27,7 @@ colored = "2.1.0"
 confy = "0.6.0"
 grocy = { path = "grocy" }
 inquire = { version = "0.6.2", features = ["date"] }
+ir.workspace = true
 lidl = { path = "lidl" }
 serde.workspace = true
 thiserror.workspace = true

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ir"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,0 +1,69 @@
+use std::fmt::Display;
+
+use anyhow::Result;
+use chrono::NaiveDateTime;
+
+pub trait StoreApi {
+    fn get_available_receipts(&self) -> Result<Vec<ReceiptSummary>>;
+    fn get_specific_receipt(&self, receipt: &ReceiptSummary) -> Result<ReceiptDetailed>;
+}
+
+#[derive(Debug)]
+pub struct Currency {
+    /// ISO 4217 code of currency
+    pub id: String,
+    /// User facing symbol of currency
+    pub symbol: String,
+}
+
+/// Used when listing available receipts; has minimal information
+#[derive(Debug)]
+pub struct ReceiptSummary {
+    pub id: String,
+    pub date: NaiveDateTime,
+    pub currency: Currency,
+    pub total_amount: f64,
+    pub articles_count: Option<u32>,
+}
+
+impl Display for ReceiptSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.date.format("%a %b %e %Y %T"))?;
+        if let Some(articles_count) = self.articles_count {
+            write!(f, " - {} product(s)", articles_count)?;
+        }
+        write!(f, " - {} {}", self.total_amount, self.currency.symbol)
+    }
+}
+
+#[derive(Debug)]
+pub struct Store {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug)]
+pub struct Discount {
+    pub amount: f64,
+}
+
+#[derive(Debug)]
+pub struct ReceiptItem {
+    /// Price per 1 of quantity
+    pub unit_price: f64,
+    /// Quantity is a float for weight-based products
+    pub quantity: f64,
+    pub is_weight: bool,
+    pub name: String,
+    pub barcode: String,
+    pub discounts: Vec<Discount>,
+}
+
+#[derive(Debug)]
+pub struct ReceiptDetailed {
+    pub id: String,
+    pub items: Vec<ReceiptItem>,
+    pub date: NaiveDateTime,
+    pub currency: Currency,
+    pub store: Store,
+}

--- a/lidl/Cargo.toml
+++ b/lidl/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
+ir.workspace = true
 oauth2 = "4.4.2"
 reqwest.workspace = true
 serde.workspace = true

--- a/src/lidl.rs
+++ b/src/lidl.rs
@@ -1,14 +1,11 @@
 use anyhow::Result;
 use inquire::{Confirm, Select, Text};
-use lidl::{
-    get_countries,
-    structs::{Country, ReceiptDetailed},
-    LidlApi, OAuthFlow,
-};
+use ir::{ReceiptDetailed, StoreApi};
+use lidl::{get_countries, structs::Country, LidlApi, OAuthFlow};
 
 use crate::{error::Error, LidlConfig, LidlLocale};
 
-pub(super) fn fetch_receipt_from_lidl(config: &mut LidlConfig) -> Result<ReceiptDetailed<f64>> {
+pub(super) fn fetch_receipt_from_lidl(config: &mut LidlConfig) -> Result<ReceiptDetailed> {
     let lidl_api = match &config.refresh_token {
         None => init_token_lidl(config)?,
         Some(refresh_token) => {
@@ -37,7 +34,7 @@ pub(super) fn fetch_receipt_from_lidl(config: &mut LidlConfig) -> Result<Receipt
     // Save refresh token to config, for future runs
     config.refresh_token = Some(lidl_api.get_refresh_token());
 
-    let receipts = lidl_api.get_available_receipts()?.receipts;
+    let receipts = lidl_api.get_available_receipts()?;
 
     let receipt = Select::new("Select receipt to import:", receipts).prompt()?;
     lidl_api.get_specific_receipt(&receipt)


### PR DESCRIPTION
Instead of using structs from the `lidl` crate when interacting with the UI and grocy, use intermediate representation structs. This paves the way for support of multiple receipt sources in the future, and also for multiple versions of the Lidl API.

See #10